### PR TITLE
PET-239 Fix to set map properties in all the bid requests

### DIFF
--- a/modules/iasBidAdapter.js
+++ b/modules/iasBidAdapter.js
@@ -59,21 +59,15 @@ function buildRequests(bidRequests) {
   queries.push(['sr', stringifyScreenSize()]);
 
   const queryString = encodeURI(queries.map(qs => qs.join('=')).join('&'));
-  const results = [
-    {
+  const results = [];
+  bidRequests.forEach(function(entry) {
+    results.push({
       method: 'GET',
       url: IAS_HOST,
       data: queryString,
-      bidRequest: bidRequests[0]
-    },
-    {
-      method: 'GET',
-      url: IAS_HOST,
-      data: queryString,
-      bidRequest: bidRequests[1]
-    }
-  ];
-
+      bidRequest: entry
+    });
+  });
   return results;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ X] Bugfix

## Description of change
https://jira.integralads.com/browse/PET-239
As a publisher, I would like to integrate IAS Publisher Optimization tool through the IAS Prebid.js adapter available here : http://prebid.org/download.html

Expected behavior :

After integration the latest version of IAS prebid.js adapter and setting all up, the tool should call DFP with IAS key/values for each AdSlot defined on the page and a campaign (multiple creatives) that targets these key/values should then display on the page.

Actual behavior :

It seems that the key/values are set up for the 1st AdSlot of the page but not for the following AdSlots on the page (tested with "googletag.pubads().getSlots()[0].getTargeting("fr")" and "googletag.pubads().getSlots()[1].getTargeting("adt")").

 